### PR TITLE
Add GDPR cookie consent banner and privacy page

### DIFF
--- a/app/components/CookieBanner.vue
+++ b/app/components/CookieBanner.vue
@@ -16,6 +16,12 @@
         </div>
       </div>
     </Transition>
+
+    <Transition name="cookie-slide">
+      <NuxtLink v-if="!visible && settled" to="/cookies" class="cookie-settings-btn" aria-label="Cookie settings">
+        <span class="material-icons" style="font-size:18px;color:#8B5E3C;">cookie</span>
+      </NuxtLink>
+    </Transition>
   </Teleport>
 </template>
 
@@ -28,25 +34,30 @@ export default {
   name: 'CookieBanner',
   setup() {
     const visible = ref(false)
+    const settled = ref(false) // true once a choice has been stored
 
     onMounted(() => {
       if (!localStorage.getItem(STORAGE_KEY)) {
         visible.value = true
+      } else {
+        settled.value = true
       }
     })
 
     function accept() {
       localStorage.setItem(STORAGE_KEY, 'accepted')
       visible.value = false
+      settled.value = true
       window.dispatchEvent(new Event('cookie-consent-accepted'))
     }
 
     function reject() {
       localStorage.setItem(STORAGE_KEY, 'rejected')
       visible.value = false
+      settled.value = true
     }
 
-    return { visible, accept, reject }
+    return { visible, settled, accept, reject }
   }
 }
 </script>
@@ -138,6 +149,41 @@ export default {
 
 .btn-accept:hover {
   background: #0052a3;
+}
+
+/* Persistent cookie settings button */
+.cookie-settings-btn {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  z-index: 1000;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.72);
+  -webkit-backdrop-filter: blur(18px) saturate(150%);
+  backdrop-filter: blur(18px) saturate(150%);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  line-height: 1;
+}
+
+.cookie-settings-btn:hover {
+  transform: scale(1.12);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14);
+}
+
+@media (max-width: 480px) {
+  .cookie-settings-btn {
+    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+    left: 16px;
+  }
 }
 
 /* Slide up / down transition */

--- a/app/components/CookieBanner.vue
+++ b/app/components/CookieBanner.vue
@@ -1,0 +1,175 @@
+<template>
+  <Teleport to="body">
+    <Transition name="cookie-slide">
+      <div v-if="visible" class="cookie-banner" role="dialog" aria-label="Cookie consent" aria-live="polite">
+        <div class="cookie-inner">
+          <div class="cookie-text">
+            <p>
+              We use cookies to improve your experience and analyse site traffic.
+              <NuxtLink to="/cookies" class="cookie-link">Learn more</NuxtLink>
+            </p>
+          </div>
+          <div class="cookie-actions">
+            <button class="btn-reject" @click="reject">Reject non-essential</button>
+            <button class="btn-accept" @click="accept">Accept all</button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue'
+
+const STORAGE_KEY = 'cookie_consent'
+
+export default {
+  name: 'CookieBanner',
+  setup() {
+    const visible = ref(false)
+
+    onMounted(() => {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        visible.value = true
+      }
+    })
+
+    function accept() {
+      localStorage.setItem(STORAGE_KEY, 'accepted')
+      visible.value = false
+      window.dispatchEvent(new Event('cookie-consent-accepted'))
+    }
+
+    function reject() {
+      localStorage.setItem(STORAGE_KEY, 'rejected')
+      visible.value = false
+    }
+
+    return { visible, accept, reject }
+  }
+}
+</script>
+
+<style scoped>
+.cookie-banner {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  width: calc(100% - 32px);
+  max-width: 760px;
+  background: rgba(255, 255, 255, 0.72);
+  -webkit-backdrop-filter: blur(18px) saturate(150%);
+  backdrop-filter: blur(18px) saturate(150%);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 1.25rem;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.10);
+  padding: 16px 20px;
+}
+
+.cookie-inner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.cookie-text {
+  flex: 1;
+  min-width: 200px;
+  font-size: 0.875rem;
+  color: #374151;
+  line-height: 1.5;
+}
+
+.cookie-text p {
+  margin: 0;
+}
+
+.cookie-link {
+  color: #0066cc;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.cookie-link:hover {
+  color: #0052a3;
+}
+
+.cookie-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.btn-reject {
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background: transparent;
+  color: #374151;
+  transition: background 0.2s ease, color 0.2s ease;
+  white-space: nowrap;
+}
+
+.btn-reject:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: #111827;
+}
+
+.btn-accept {
+  padding: 8px 20px;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  background: #0066cc;
+  color: #fff;
+  transition: background 0.2s ease;
+  white-space: nowrap;
+}
+
+.btn-accept:hover {
+  background: #0052a3;
+}
+
+/* Slide up / down transition */
+.cookie-slide-enter-active,
+.cookie-slide-leave-active {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.cookie-slide-enter-from,
+.cookie-slide-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(16px);
+}
+
+@media (max-width: 480px) {
+  .cookie-banner {
+    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .cookie-inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cookie-actions {
+    flex-direction: column;
+  }
+
+  .btn-reject,
+  .btn-accept {
+    width: 100%;
+    text-align: center;
+  }
+}
+</style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -4,11 +4,12 @@
     <main class="m-0 p-0 flex-grow">
       <slot />
     </main>
-    <!-- Footer container and ad banner removed -->
+    <CookieBanner />
   </div>
 </template>
 
 <script setup>
+import CookieBanner from '~/components/CookieBanner.vue'
 useHead({
   link: [
     { rel: 'preconnect', href: 'https://fonts.googleapis.com' },

--- a/app/pages/cookies.vue
+++ b/app/pages/cookies.vue
@@ -1,0 +1,279 @@
+<template>
+  <div class="page-bg min-h-screen px-4 pb-16 pt-24">
+    <div class="max-w-3xl mx-auto">
+      <div class="bg-white p-8 lg:p-12 rounded-[2rem] shadow-sm">
+
+        <h1 class="text-3xl font-bold mb-2">Cookie &amp; Privacy Policy</h1>
+        <p class="text-sm text-gray-400 mb-8">Last updated: June 2026</p>
+
+        <!-- 1. What are cookies -->
+        <section class="mb-10">
+          <h2 class="section-heading">What are cookies?</h2>
+          <p class="body-text">
+            Cookies are small text files placed on your device when you visit a website.
+            We also use <em>localStorage</em> — a similar browser storage mechanism — to remember
+            your preferences. This policy covers both.
+          </p>
+        </section>
+
+        <!-- 2. Cookies we use -->
+        <section class="mb-10">
+          <h2 class="section-heading">Cookies we use</h2>
+          <p class="body-text mb-4">
+            We keep our use of cookies to a minimum. Below is the full list.
+          </p>
+          <div class="overflow-x-auto">
+            <table class="cookie-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Purpose</th>
+                  <th>Retention</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>cookie_consent</code></td>
+                  <td><span class="badge badge-essential">Essential</span></td>
+                  <td>Stores your cookie preference (accepted / rejected) so we don't ask again.</td>
+                  <td>Until you clear it or change your choice</td>
+                </tr>
+                <tr>
+                  <td><code>_ga</code></td>
+                  <td><span class="badge badge-analytics">Analytics</span></td>
+                  <td>Google Analytics 4 — distinguishes unique users. Only set if you accept analytics cookies.</td>
+                  <td>2 years</td>
+                </tr>
+                <tr>
+                  <td><code>_ga_*</code></td>
+                  <td><span class="badge badge-analytics">Analytics</span></td>
+                  <td>Google Analytics 4 — maintains session state. Only set if you accept analytics cookies.</td>
+                  <td>2 years</td>
+                </tr>
+                <tr>
+                  <td><code>_gid</code></td>
+                  <td><span class="badge badge-analytics">Analytics</span></td>
+                  <td>Google Analytics — distinguishes users within a session. Only set if you accept analytics cookies.</td>
+                  <td>24 hours</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="body-text mt-4 text-sm text-gray-500">
+            Analytics cookies are only placed after you explicitly accept them. If you reject
+            non-essential cookies, only the <code>cookie_consent</code> preference is stored.
+          </p>
+        </section>
+
+        <!-- 3. Data controller -->
+        <section class="mb-10">
+          <h2 class="section-heading">Data controller</h2>
+          <p class="body-text">
+            The data controller for PublicTransport.is is:
+          </p>
+          <address class="body-text not-italic mt-2 pl-4 border-l-2 border-gray-200">
+            <strong>Hjólafærni á Íslandi</strong><br>
+            <a href="https://www.hjolafaerni.is" target="_blank" class="text-link">www.hjolafaerni.is</a><br>
+            Email: <a href="mailto:info@hjolafaerni.is" class="text-link">info@hjolafaerni.is</a>
+          </address>
+          <p class="body-text mt-4">
+            Google Analytics data is processed by Google Ireland Limited under
+            the EU–US Data Privacy Framework. For more information see
+            <a href="https://policies.google.com/privacy" target="_blank" class="text-link">Google's privacy policy</a>.
+          </p>
+        </section>
+
+        <!-- 4. GDPR rights -->
+        <section class="mb-10">
+          <h2 class="section-heading">Your rights under GDPR</h2>
+          <p class="body-text mb-3">
+            If you are located in the European Economic Area, you have the following rights
+            regarding your personal data:
+          </p>
+          <ul class="rights-list">
+            <li><strong>Access</strong> — request a copy of the data we hold about you.</li>
+            <li><strong>Rectification</strong> — request correction of inaccurate data.</li>
+            <li><strong>Erasure</strong> — request deletion of your data ("right to be forgotten").</li>
+            <li><strong>Restriction</strong> — request that we limit how we process your data.</li>
+            <li><strong>Portability</strong> — receive your data in a structured, machine-readable format.</li>
+            <li><strong>Objection</strong> — object to processing based on legitimate interest.</li>
+            <li><strong>Withdraw consent</strong> — withdraw analytics consent at any time (see below). This does not affect the lawfulness of processing before withdrawal.</li>
+          </ul>
+          <p class="body-text mt-4">
+            To exercise any of these rights, contact us at
+            <a href="mailto:info@hjolafaerni.is" class="text-link">info@hjolafaerni.is</a>.
+            You also have the right to lodge a complaint with the
+            <a href="https://www.personuvernd.is" target="_blank" class="text-link">Icelandic Data Protection Authority (Persónuvernd)</a>.
+          </p>
+        </section>
+
+        <!-- 5. Change your choice -->
+        <section class="mb-10">
+          <h2 class="section-heading">Change your cookie preference</h2>
+          <p class="body-text mb-4">
+            You can withdraw or change your consent at any time by clicking the button below.
+            Your choice will be reset and the consent banner will reappear on your next page load.
+          </p>
+          <button class="btn-reset" @click="resetConsent">
+            Reset cookie preference
+          </button>
+          <p v-if="resetDone" class="mt-3 text-sm text-green-600 font-medium">
+            Preference cleared. Reload the page to see the consent banner again.
+          </p>
+        </section>
+
+        <!-- 6. Contact -->
+        <section>
+          <h2 class="section-heading">Contact</h2>
+          <p class="body-text">
+            For any questions about this policy or your data, email us at
+            <a href="mailto:info@hjolafaerni.is" class="text-link">info@hjolafaerni.is</a>.
+          </p>
+        </section>
+
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue'
+
+export default {
+  name: 'CookiesPage',
+  setup() {
+    const resetDone = ref(false)
+
+    function resetConsent() {
+      localStorage.removeItem('cookie_consent')
+      resetDone.value = true
+    }
+
+    return { resetDone, resetConsent }
+  }
+}
+</script>
+
+<style scoped>
+.section-heading {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 0.75rem;
+}
+
+.body-text {
+  font-size: 0.95rem;
+  color: #374151;
+  line-height: 1.7;
+}
+
+.text-link {
+  color: #0066cc;
+  text-decoration: underline;
+}
+
+.text-link:hover {
+  color: #0052a3;
+}
+
+/* Cookie table */
+.cookie-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  color: #374151;
+}
+
+.cookie-table th {
+  text-align: left;
+  padding: 10px 12px;
+  background: #f9fafb;
+  border-bottom: 2px solid #e5e7eb;
+  font-weight: 600;
+  color: #111827;
+  white-space: nowrap;
+}
+
+.cookie-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #f0f0f0;
+  vertical-align: top;
+}
+
+.cookie-table tr:last-child td {
+  border-bottom: none;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.badge-essential {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.badge-analytics {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+code {
+  font-family: ui-monospace, 'Cascadia Code', monospace;
+  font-size: 0.8em;
+  background: #f3f4f6;
+  padding: 1px 5px;
+  border-radius: 4px;
+  color: #1f2937;
+}
+
+/* Rights list */
+.rights-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rights-list li {
+  font-size: 0.95rem;
+  color: #374151;
+  line-height: 1.6;
+  padding-left: 1.2rem;
+  position: relative;
+}
+
+.rights-list li::before {
+  content: '–';
+  position: absolute;
+  left: 0;
+  color: #9ca3af;
+}
+
+/* Reset button */
+.btn-reset {
+  padding: 10px 22px;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1.5px solid #0066cc;
+  background: transparent;
+  color: #0066cc;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.btn-reset:hover {
+  background: #0066cc;
+  color: #fff;
+}
+</style>

--- a/app/plugins/google-analytics.client.js
+++ b/app/plugins/google-analytics.client.js
@@ -2,54 +2,57 @@
 export default defineNuxtPlugin((nuxtApp) => {
   const runtimeConfig = useRuntimeConfig()
   const measurementId = runtimeConfig.public.googleAnalyticsMeasurementId
+  const isValidId = /^G-[A-Z0-9]+$/i.test(measurementId)
 
-  // Only load on client-side and if a valid measurement ID is provided
-  // Valid Google Analytics 4 IDs start with G- followed by alphanumeric characters
-  const isValidId = /^G-[A-Z0-9]+$/i.test(measurementId);
-
-  if (process.client && measurementId && isValidId) {
-    // Load the Google Analytics script
-    function loadGoogleAnalytics() {
-      const script = document.createElement('script')
-      script.async = true
-      script.src = 'https://www.googletagmanager.com/gtag/js?id=' + measurementId;
-      document.head.appendChild(script)
-      
-      window.dataLayer = window.dataLayer || []
-      function gtag() {
-        window.dataLayer.push(arguments)
-      }
-      
-      gtag('js', new Date())
-      gtag('config', measurementId)
-      
-      // Make gtag available globally
-      window.gtag = gtag
-      
-      return gtag
-    }
-    
-    // Defer loading until DOM is ready
-    document.addEventListener('DOMContentLoaded', () => {
-      // Initialize GA
-      const gtag = loadGoogleAnalytics()
-      
-      // Add to Vue context
-      nuxtApp.provide('gtag', (event, action, params = {}) => {
-        if (window.gtag) {
-          // console.log('Tracking event:', event, action, params) // Keep original commented log if desired, or remove
-          window.gtag('event', event, {
-            action: action,
-            ...params
-          })
-        }
-      })
-    });
-  } else {
-    // Provide a dummy function when GA is not loaded
+  if (!process.client || !measurementId || !isValidId) {
     nuxtApp.provide('gtag', () => {
-      // Do nothing in SSR or when no measurement ID is available
-      console.log('Google Analytics not loaded: Invalid or missing measurement ID') // Restore original log message
+      console.log('Google Analytics not loaded: Invalid or missing measurement ID')
     })
+    return
   }
-}) 
+
+  let initialized = false
+
+  function loadGoogleAnalytics() {
+    if (initialized) return
+    initialized = true
+
+    const script = document.createElement('script')
+    script.async = true
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + measurementId
+    document.head.appendChild(script)
+
+    window.dataLayer = window.dataLayer || []
+    function gtag() { window.dataLayer.push(arguments) }
+    gtag('js', new Date())
+    gtag('config', measurementId)
+    window.gtag = gtag
+  }
+
+  // Provide $gtag — works whether GA loaded or not (gtag buffers via dataLayer)
+  nuxtApp.provide('gtag', (event, action, params = {}) => {
+    if (window.gtag) {
+      window.gtag('event', event, { action, ...params })
+    }
+  })
+
+  // Init GA now if consent already given, otherwise wait for the banner event
+  const initIfConsented = () => {
+    if (localStorage.getItem('cookie_consent') === 'accepted') {
+      loadGoogleAnalytics()
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initIfConsented)
+  } else {
+    initIfConsented()
+  }
+
+  // Verify localStorage before acting — prevents spoofed events from bypassing consent
+  window.addEventListener('cookie-consent-accepted', () => {
+    if (localStorage.getItem('cookie_consent') === 'accepted') {
+      loadGoogleAnalytics()
+    }
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "pt2",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@vue-leaflet/vue-leaflet": "^0.10.1",
         "axios": "^1.6.7",


### PR DESCRIPTION
## Summary

- **`CookieBanner.vue`** — bottom-fixed glass banner with Accept / Reject buttons; persists choice to `localStorage('cookie_consent')`; slides in on first visit, disappears after choice; shows a persistent 🍪 cookie icon button (bottom-left) after consent is given, linking back to `/cookies`
- **`/cookies` page** — full cookie policy with cookie table (essential vs analytics), GDPR rights, data controller info (Hjólafærni á Íslandi), and a reset-consent button
- **GA plugin** — now consent-aware: only loads after explicit accept; guards against event spoofing by verifying `localStorage` before acting on `cookie-consent-accepted`
- **`default.vue`** — includes `<CookieBanner />` in the shared layout

## GDPR compliance notes

- Analytics cookies only fire after explicit opt-in
- Site remains accessible regardless of choice (no cookie wall)
- User can withdraw consent at any time via `/cookies` → Reset button
- `cookie_consent` (localStorage) is the only essential storage placed without consent

## Test plan

- [ ] Clear localStorage and reload — banner appears
- [ ] Accept → banner disappears, cookie icon appears bottom-left, GA loads
- [ ] Reject → banner disappears, cookie icon appears, GA does not load
- [ ] Click cookie icon → navigates to `/cookies`
- [ ] Reset consent on `/cookies` page → banner reappears on next load
- [ ] Verify `/cookies` page renders correctly on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)